### PR TITLE
Add option to use select2's placeholder as title

### DIFF
--- a/dal_admin_filters/__init__.py
+++ b/dal_admin_filters/__init__.py
@@ -11,6 +11,7 @@ class AutocompleteFilter(SimpleListFilter):
     title = ''
     parameter_name = ''
     autocomplete_url = ''
+    is_placeholder_title = False
 
     class Media:
         css = {
@@ -36,9 +37,12 @@ class AutocompleteFilter(SimpleListFilter):
         field = forms.ModelChoiceField(
             queryset=getattr(model, self.parameter_name).get_queryset(),
             widget=autocomplete.ModelSelect2(
-                url=self.autocomplete_url
+                url=self.autocomplete_url,
             )
         )
+
+        if self.is_placeholder_title:
+            field.widget.attrs = {'data-placeholder' : "By " + self.title}
 
         self.rendered_widget = field.widget.render(
             name=self.parameter_name, value=self.used_parameters.get(self.parameter_name, '')

--- a/dal_admin_filters/templates/dal_admin_filters/autocomplete-filter.html
+++ b/dal_admin_filters/templates/dal_admin_filters/autocomplete-filter.html
@@ -1,5 +1,7 @@
 {% load i18n %}
-<h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
+{% if not spec.is_placeholder_title %}
+    <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
+{% endif %}
 <ul>
     <li>{{ spec.rendered_widget }}</li>
 </ul>


### PR DESCRIPTION
Allows the select2 field's placeholder attribute to display the title
when having the title displayed externally does not fit styling.