### PR TITLE
Rename `parameter_name` to `field_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ Refer to http://django-autocomplete-light.readthedocs.io/ for more detailed inst
     
     class CountryFilter(AutocompleteFilter):
         title = 'Country from'                    # filter's title
-        parameter_name = 'from_country'           # field name - ForeignKey to Country model
+        field_name = 'from_country'           # field name - ForeignKey to Country model
         autocomplete_url = 'country-autocomplete' # url name of Country autocomplete view
     
     
     class CountryPlaceholderFilter(AutocompleteFilter):
         title = 'Country from'                    # filter's title
-        parameter_name = 'from_country'           # field name - ForeignKey to Country model
+        field_name = 'from_country'           # field name - ForeignKey to Country model
         autocomplete_url = 'country-autocomplete' # url name of Country autocomplete view
         is_placeholder_title = True               # filter title will be shown as placeholder
     

--- a/README.rst
+++ b/README.rst
@@ -122,13 +122,13 @@ Configuration
 
        class CountryFilter(AutocompleteFilter):
            title = 'Country from'                    # filter's title
-           parameter_name = 'from_country'           # field name - ForeignKey to Country model
+           field_name = 'from_country'           # field name - ForeignKey to Country model
            autocomplete_url = 'country-autocomplete' # url name of Country autocomplete view
 
 
        class CountryPlaceholderFilter(AutocompleteFilter):
            title = 'Country from'                    # filter's title
-           parameter_name = 'from_country'           # field name - ForeignKey to Country model
+           field_name = 'from_country'           # field name - ForeignKey to Country model
            autocomplete_url = 'country-autocomplete' # url name of Country autocomplete view
            is_placeholder_title = True               # filter title will be shown as placeholder
 
@@ -144,3 +144,12 @@ Configuration
 
 If setup is done right, you will see the Select2 widget in admin filter
 in Person's changelist view.
+
+
+Change log
+------------
+
+Upcoming:
+
+* rename `parameter_name` to `field_name`
+* 

--- a/dal_admin_filters/__init__.py
+++ b/dal_admin_filters/__init__.py
@@ -9,7 +9,7 @@ from django.forms.widgets import Media, MEDIA_TYPES
 class AutocompleteFilter(SimpleListFilter):
     template = "dal_admin_filters/autocomplete-filter.html"
     title = ''
-    parameter_name = ''
+    field_name = ''
     autocomplete_url = ''
     is_placeholder_title = False
 
@@ -30,12 +30,18 @@ class AutocompleteFilter(SimpleListFilter):
         )
 
     def __init__(self, request, params, model, model_admin):
+        if self.parameter_name:
+            raise AttributeError(
+                'Rename attribute `parameter_name` to '
+                '`field_name` for {}'.format(self.__class__)
+            )
+        self.parameter_name = '{}__id__exact'.format(self.field_name)
         super(AutocompleteFilter, self).__init__(request, params, model, model_admin)
 
         self._add_media(model_admin)
 
         field = forms.ModelChoiceField(
-            queryset=getattr(model, self.parameter_name).get_queryset(),
+            queryset=getattr(model, self.field_name).get_queryset(),
             widget=autocomplete.ModelSelect2(
                 url=self.autocomplete_url,
             )
@@ -45,7 +51,8 @@ class AutocompleteFilter(SimpleListFilter):
             field.widget.attrs = {'data-placeholder' : "By " + self.title}
 
         self.rendered_widget = field.widget.render(
-            name=self.parameter_name, value=self.used_parameters.get(self.parameter_name, '')
+            name=self.parameter_name,
+            value=self.used_parameters.get(self.parameter_name, '')
         )
 
     def _add_media(self, model_admin):
@@ -69,7 +76,6 @@ class AutocompleteFilter(SimpleListFilter):
 
     def queryset(self, request, queryset):
         if self.value():
-            lookup = "%s__id__exact" % self.parameter_name
-            return queryset.filter(**{lookup: self.value()})
+            return queryset.filter(**{self.parameter_name: self.value()})
         else:
             return queryset

--- a/demo_project/notes/admin.py
+++ b/demo_project/notes/admin.py
@@ -10,13 +10,13 @@ class CountryAdmin(admin.ModelAdmin):
 
 class CountryFilter(AutocompleteFilter):
     title = 'Country from'
-    parameter_name = 'from_country'
+    field_name = 'from_country'
     autocomplete_url = 'country-autocomplete'
 
 
 class CountryPlaceholderFilter(AutocompleteFilter):
     title = 'Country from'
-    parameter_name = 'from_country'
+    field_name = 'from_country'
     autocomplete_url = 'country-autocomplete'
     is_placeholder_title = True
 

--- a/demo_project/requirements.txt
+++ b/demo_project/requirements.txt
@@ -1,6 +1,6 @@
 args==0.1.0
 clint==0.5.1
-dal-admin-filters==0.1.7
+dal-admin-filters==0.1.7  # TODO: update me
 Django==1.10
 django-autocomplete-light==3.1.8
 pkginfo==1.3.2

--- a/demo_project/requirements.txt
+++ b/demo_project/requirements.txt
@@ -1,6 +1,6 @@
 args==0.1.0
 clint==0.5.1
-dal-admin-filters==0.1.3
+dal-admin-filters==0.1.7
 Django==1.10
 django-autocomplete-light==3.1.8
 pkginfo==1.3.2


### PR DESCRIPTION
With this rename, `{}__id_exact` is added to parameter name and `AutocompleteAdminFilter` will act like django's default filter for ForeignKey.

This may be useful if you use `ForeignKey.get_forward_related_filter` for constructing filters
