### PR TITLE
fix select2_container width

### DIFF
--- a/dal_admin_filters/static/dal_admin_filters/css/autocomplete-fix.css
+++ b/dal_admin_filters/static/dal_admin_filters/css/autocomplete-fix.css
@@ -1,3 +1,4 @@
-    .select2-container {
-        min-width: 16.5em;
-    }
+.select2-container {
+    min-width: 16.5em;
+    max-width: 100%;
+}


### PR DESCRIPTION
Fix ` .select2-container` width, when it doesn't fit to `.changelist-filter` because of long value.

![screenshot_2017-08-09_11-14-27](https://user-images.githubusercontent.com/19373363/29113240-31eb086c-7cf9-11e7-83bd-905d078f04e8.png)
