### PR TITLE
Make dependencies less restrictive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==2.1.7
-django-autocomplete-light==3.3.2
+Django>=2.0.0
+django-autocomplete-light>=3.3.2


### PR DESCRIPTION
I've noticed that dependencies were incorrect because 
https://github.com/yourlabs/django-autocomplete-light/tree/3.2.2
don't support django 2.0 :( first mention about django 2.0 is here:
https://github.com/yourlabs/django-autocomplete-light/tree/3.3.4

Pinning dependencies for libraries is bad pattern, it causes conflicts. I'm not sure if what I made is not too loose, but should still be an improvement.

Tested locally on
```
django==2.0.13
django-autocomplete-light==3.3.5
```