### PR TITLE
Forward, Django 3, etc.

### DIFF
--- a/dal_admin_filters/__init__.py
+++ b/dal_admin_filters/__init__.py
@@ -10,6 +10,7 @@ class AutocompleteFilter(SimpleListFilter):
     title = ''
     field_name = ''
     field_pk = 'id'
+    use_pk_exact = True
     autocomplete_url = ''
     is_placeholder_title = False
     widget_attrs = {}
@@ -33,12 +34,10 @@ class AutocompleteFilter(SimpleListFilter):
         )
 
     def __init__(self, request, params, model, model_admin):
-        if self.parameter_name:
-            raise AttributeError(
-                'Rename attribute `parameter_name` to '
-                '`field_name` for {}'.format(self.__class__)
-            )
-        self.parameter_name = '{}__{}__exact'.format(self.field_name, self.field_pk)
+        if self.parameter_name is None:
+            self.parameter_name = self.field_name
+            if self.use_pk_exact:
+                self.parameter_name += '__{}__exact'.format(self.field_pk)
         super(AutocompleteFilter, self).__init__(request, params, model, model_admin)
 
         self._add_media(model_admin)

--- a/dal_admin_filters/static/dal_admin_filters/css/autocomplete-fix.css
+++ b/dal_admin_filters/static/dal_admin_filters/css/autocomplete-fix.css
@@ -1,4 +1,4 @@
-.select2-container {
+#changelist-filter .select2-container {
     min-width: 16.5em;
     max-width: 100%;
 }

--- a/dal_admin_filters/static/dal_admin_filters/js/forward-fix.js
+++ b/dal_admin_filters/static/dal_admin_filters/js/forward-fix.js
@@ -1,0 +1,5 @@
+(function ($) {
+    $(document).ready(function () {
+        $('#changelist-filter').children().wrapAll('<form></form>'); // required for forward func
+    });
+})(yl.jQuery);


### PR DESCRIPTION
Hi, I made some changes for my project. But maybe they will come in handy here?

 - added forward function
 - added media loading from the widget
 - creating a media class in the admin_model, if it has not been created (now empty media class is not needed)
 - the creation of the widget has been moved to a separate function so that you can override it
 - setting the parameter name manually, to work around the error "DisallowedModelAdminLookup"

I checked the work of these changes on Django version 3.0.7