### PR TITLE
remove django-autocomplete-light static files

### DIFF
--- a/dal_admin_filters/__init__.py
+++ b/dal_admin_filters/__init__.py
@@ -20,18 +20,13 @@ class AutocompleteFilter(SimpleListFilter):
         css = {
             'all': (
                 'dal_admin_filters/css/select2.min.css',
-                'autocomplete_light/select2.css',
                 'dal_admin_filters/css/autocomplete-fix.css'
             )
         }
         js = (
             'admin/js/jquery.init.js',
-            'autocomplete_light/jquery.init.js',
             'dal_admin_filters/js/forward-fix.js',
             'dal_admin_filters/js/select2.full.min.js',
-            'autocomplete_light/autocomplete.init.js',
-            'autocomplete_light/forward.js',
-            'autocomplete_light/select2.js',
             'dal_admin_filters/js/querystring.js',
         )
 

--- a/dal_admin_filters/static/dal_admin_filters/js/forward-fix.js
+++ b/dal_admin_filters/static/dal_admin_filters/js/forward-fix.js
@@ -2,4 +2,4 @@
     $(document).ready(function () {
         $('#changelist-filter').children().wrapAll('<form></form>'); // required for forward func
     });
-})(yl.jQuery);
+})(django.jQuery);

--- a/dal_admin_filters/templates/dal_admin_filters/autocomplete-filter.html
+++ b/dal_admin_filters/templates/dal_admin_filters/autocomplete-filter.html
@@ -15,5 +15,5 @@
                     window.location.search = search_replace('{{ spec.parameter_name }}', val);
                 });
         });
-    })(yl.jQuery);
+    })(django.jQuery);
 </script>


### PR DESCRIPTION
Hi everyone,
First of all thank you for efforts into this great project!

That said we recently had compatibility issues updating to recent versions of `django-autocomplete-light`, caused by changes made to static files.
In particular `dal` from 3.7.0 has removed the `autocomplete.init.js` script due to a complete rework of the initialization system, so at the moment trying to load it from `AutocompleteFilter` can cause some requests to fail with 404 or worse if the file is still present as a stale static object (it breaks the widget).

Since all these static assets inherited from `django-autocomplete-light` should be already loaded by `ModelSelect2` widget seems reasonable to remove them from filter's media so that the widget alone can pick the correct ones regardless of the version installed. 